### PR TITLE
fix: the audio library uses vsprintf() at line 4678 ... in...

### DIFF
--- a/c/miniaudio_io.h
+++ b/c/miniaudio_io.h
@@ -4675,7 +4675,7 @@ vsprintf_s(pFormattedMessage,formattedLen+1,pFormat,args);
 }
 #else
 {
-vsprintf(pFormattedMessage,pFormat,args);
+vsnprintf(pFormattedMessage,formattedLen+1,pFormat,args);
 }
 #endif
 Mf=ma_log_post(pLog,level,pFormattedMessage);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `c/miniaudio_io.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `c/miniaudio_io.h:4678` |

**Description**: The audio library uses vsprintf() at line 4678 without any buffer size constraint. vsprintf writes formatted output to pFormattedMessage without knowing the destination buffer's allocated size. A sufficiently long format string or its arguments will write beyond the end of the buffer, overwriting adjacent stack or heap memory. This is a textbook CWE-120 (Buffer Copy without Checking Size of Input) vulnerability with a confirmed code location.

## Changes
- `c/miniaudio_io.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
