### PR TITLE
fix: Sanitize folder names to prevent invalid characters error

### DIFF
--- a/sff/cloud_saves.py
+++ b/sff/cloud_saves.py
@@ -612,10 +612,12 @@ def _resolve_game_name(folder_name, name_map_cache=None):
             except Exception:
                 pass
         game_name = name or f"App {app_id}"
-        label = f"{app_id} - {game_name}"
+        sanitized_game_name = "".join(c if c not in r'\/:*?"<>|' else "_" for c in game_name)
+        label = f"{app_id} - {sanitized_game_name}"
         return app_id, game_name, label
     else:
-        return None, folder_name, folder_name
+        sanitized_folder_name = "".join(c if c not in r'\/:*?"<>|' else "_" for c in folder_name)
+        return None, folder_name, sanitized_folder_name
 
 
 def scan_all_save_locations(steam_path=None, steam32_id=None):
@@ -754,7 +756,8 @@ def scan_all_save_locations(steam_path=None, steam32_id=None):
                                 break
             except Exception:
                 pass
-            label = f"{app_id_int} - {game_name}" if app_id_int else game_name
+            safe_game_name = "".join(c if c not in r'\/:*?"<>|' else "_" for c in game_name)
+            label = f"{app_id_int} - {safe_game_name}" if app_id_int else safe_game_name
             results.append({
                 "location": "Custom Path",
                 "folder_name": src.name,


### PR DESCRIPTION
**Goal:** Fixed an issue where game-names with special characters were failing to be backed up:

**Issue:** ```[FAIL] 1903340 - Clair Obscur: Expedition 33: [WinError 267] The directory name is invalid: 'E:\\SteaMidra\\SteaMidraAllSaves\\Steam Userdata\\1903340 - Clair Obscur: Expedition 33'```
```[FAIL] 1182900 - A Plague Tale: Requiem: [WinError 267] The directory name is invalid: 'E:\\SteaMidra\\SteaMidraAllSaves\\Public Steam CODEX\\1182900 - A Plague Tale: Requiem'```

**Example:** This is sanitize the game-names before creating the folder
`Clair Obscur: Expedition 33 -> Clair Obscur_ Expedition 33`