### PR TITLE
fix: Terminal flash for subprocesses on windows

### DIFF
--- a/sff/fix_game/cache.py
+++ b/sff/fix_game/cache.py
@@ -61,6 +61,7 @@ def _ensure_defender_exclusion(path):
         return  # already confirmed excluded in a previous run
 
     try:
+        _no_window = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
         result = subprocess.run(
             [
                 "powershell", "-NonInteractive", "-WindowStyle", "Hidden",
@@ -68,6 +69,7 @@ def _ensure_defender_exclusion(path):
                 f"Add-MpPreference -ExclusionPath '{path}' -ErrorAction Stop",
             ],
             capture_output=True, timeout=10,
+            **_no_window,
         )
         if result.returncode == 0:
             try:

--- a/sff/fix_game/goldberg_applier.py
+++ b/sff/fix_game/goldberg_applier.py
@@ -640,11 +640,13 @@ SteamClient={'steamclient64.dll' if is_64 else 'steamclient.dll'}
                 f'$s.IconLocation="{icon_loc},0";'
                 f'$s.Save()'
             )
+            _no_window = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
             subprocess.run(
                 ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_script],
                 check=True,
                 capture_output=True,
                 timeout=10,
+                **_no_window,
             )
             log(f"\u2713 Created desktop shortcut: {lnk_path.name}")
         except Exception as e:

--- a/sff/fix_game/goldberg_updater.py
+++ b/sff/fix_game/goldberg_updater.py
@@ -362,9 +362,11 @@ class GoldbergUpdater:
                 continue
             # 7-Zip: safe to run --help (prints to stdout and exits cleanly)
             try:
+                _no_window = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
                 result = subprocess.run(
                     [candidate, "--help"],
                     capture_output=True, timeout=5,
+                    **_no_window,
                 )
                 if result.returncode in (0, 1):
                     return candidate, tool_type
@@ -408,6 +410,7 @@ class GoldbergUpdater:
         try:
             archive_path.write_bytes(archive_data)
             extract_dir.mkdir(exist_ok=True)
+            _no_window = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
             # Linux: use system tar for .tar.bz2
             if linux_native:
                 tar_exe = shutil.which("tar")
@@ -415,7 +418,7 @@ class GoldbergUpdater:
                     log("'tar' not found — install tar (usually pre-installed on Linux)")
                     return False
                 cmd = [tar_exe, "xjf", str(archive_path), "-C", str(extract_dir)]
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, **_no_window)
                 if result.returncode != 0:
                     log(f"tar extraction failed: {result.stderr}")
                     return False
@@ -434,7 +437,7 @@ class GoldbergUpdater:
                     cmd = [exe, "x", str(archive_path), f"-o{extract_dir}", "-y"]
                 else:  # winrar
                     cmd = [exe, "x", "-y", str(archive_path), str(extract_dir) + "\\"]
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, **_no_window)
                 if result.returncode != 0:
                     log(f"{tool_name} extraction failed: {result.stderr}")
                     return False

--- a/sff/fix_game/steamstub_unpacker.py
+++ b/sff/fix_game/steamstub_unpacker.py
@@ -35,6 +35,7 @@ import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+_CREATE_NO_WINDOW = {"creationflags": 0x08000000} if sys.platform == "win32" else {}
 
 # Steamless binary names. Windows: .NET 9 self-contained .exe shipped
 # under third_party/. Linux: .NET 9 framework-dependent .dll shipped
@@ -285,6 +286,7 @@ class SteamStubUnpacker:
                 timeout=120,
                 cwd=str(Path(self.steamless_path).parent),
                 env=run_env,
+                **_CREATE_NO_WINDOW,
             )
             # Surface Steamless output on failure so users can see which
             # variant tried and why. Without this every failed unpack

--- a/sff/game_specific.py
+++ b/sff/game_specific.py
@@ -245,11 +245,14 @@ class GameHandler:
             extra_args.extend(["-skip_con", "-skip_inv"])
         cmds = [str(config_exe.absolute()), "-clean", *extra_args, app_id]
         logger.debug(f"Running {shlex.join(cmds)}")
-        subprocess.run(
-            cmds,
-            env=env,
-            cwd=str(tools_folder.absolute()),
-        )
+        _run_kwargs = {
+            "env": env,
+            "cwd": str(tools_folder.absolute()),
+        }
+        if sys.platform == "win32":
+            _run_kwargs["creationflags"] = 0x08000000
+
+        subprocess.run(cmds, **_run_kwargs)
         backup_folder = tools_folder / f"backup/{app_id}"
         src_steam_settings = tools_folder / f"output/{app_id}/steam_settings"
         steam_stats_folder = self.steam_root / "appcache/stats"

--- a/sff/steamauto.py
+++ b/sff/steamauto.py
@@ -197,14 +197,17 @@ def run_steamauto(
 
     cmd = [str(cli), "crack", str(game_path), "--appid", app_id or "0", *config_arg]
     print_func("Running: " + " ".join(cmd) + "\n")
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(cli.parent),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        encoding="utf-8",
-        errors="replace",
-    )
+    _popen_kwargs = {
+        "cwd": str(cli.parent),
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+    if sys.platform == "win32":
+        _popen_kwargs["creationflags"] = 0x08000000
+
+    proc = subprocess.Popen(cmd, **_popen_kwargs)
     assert proc.stdout is not None
     for line in proc.stdout:
         print_func(line.rstrip())


### PR DESCRIPTION
Fixes an issue where there were terminal flash on every subprocess like for using steamautocrack, or for backing up games