### PR TITLE
fix: Steam games list refresh button flex alignment

### DIFF
--- a/sff/webui/js/app.js
+++ b/sff/webui/js/app.js
@@ -418,7 +418,7 @@ window.App = (function() {
         var srcOutside = document.getElementById('game-source-outside');
         if (srcSteam) srcSteam.addEventListener('change', function() {
             _outsideMode = false;
-            document.getElementById('steam-mode-row').style.display   = '';
+            document.getElementById('steam-mode-row').style.display   = 'flex';
             document.getElementById('outside-mode-row').style.display  = 'none';
         });
         if (srcOutside) srcOutside.addEventListener('change', function() {


### PR DESCRIPTION
This PR addresses a layout issue where the "Refresh Steam games list" button, triggered by the game selection radio button, was incorrectly rendering on a new line instead of adhering to the intended flex container behavior.