### PR TITLE
fix run_download: undefined app_id/logger, download_dir used before assigned

### DIFF
--- a/sff/downloads/depot_downloader.py
+++ b/sff/downloads/depot_downloader.py
@@ -267,6 +267,8 @@ def run_download(
     depots = game_data.get("depots", {})
     manifests = dict(game_data.get("manifests", {}) or {})
     installdir = game_data.get("installdir") or f"App_{appid}"
+    download_dir = dest_path / "steamapps" / "common" / installdir
+    download_dir.mkdir(parents=True, exist_ok=True)
 
     # Auto-fill manifests from the staging dir for any selected depot
     # the caller did not pin a manifest for. The staging dir is what
@@ -333,7 +335,7 @@ def run_download(
                         if mf.exists():
                             manifest_path = mf
                     ok, size = _native_dl(
-                        app_id, depot_id_str, manifest_id, key, download_dir,
+                        appid, depot_id_str, manifest_id, key, download_dir,
                         print_fn=print_fn, os_filter=os_name or "linux",
                         steam_path=steam_path,
                         manifest_path=manifest_path,
@@ -345,7 +347,6 @@ def run_download(
                         all_ok = False
                 except Exception as e:
                     print_fn(Fore.RED + f"Native download failed for depot {depot_id_str}: {e}" + Style.RESET_ALL)
-                    logger.exception("Native downloader: depot %s failed", depot_id_str)
                     all_ok = False
             try:
                 KEYS_TMP.unlink(missing_ok=True)
@@ -389,9 +390,6 @@ def run_download(
 
     if sys.platform.startswith("linux"):
         _add_bundled_openssl_to_env(env, dotnet_root)
-
-    download_dir = dest_path / "steamapps" / "common" / installdir
-    download_dir.mkdir(parents=True, exist_ok=True)
 
     MANIFESTS_TMP.mkdir(parents=True, exist_ok=True)
     deps_dir = get_deps_dir()


### PR DESCRIPTION
the linux native branch of `run_download` has 3 name bugs that make it crash 100% of the time:

1. line 336 calls `_native_dl(app_id, ...)` but the variable is `appid` — `app_id` doesn't exist
2. line 348 calls `logger.exception(...)` but there's no `logger` defined in the module
3. `download_dir` is used at line 336/354 but only assigned later in the DDMod branch (line 393)

so on linux the native path always NameErrors, gets swallowed by the big try/except, and silently falls back to DDMod. works, but you never actually use the native downloader even when you want to.

fixes:
- pass `appid` instead of `app_id`
- drop the dead `logger.exception` line (the same error is already printed right above it)
- compute `download_dir` next to `installdir` and remove the duplicate assignment in the DDMod branch

tested via a headless wrapper driving `run_download` directly — native download now works without the .NET fallback.