### PR TITLE
LumaCore: multi-instance safe diversion artifact (fixes second Steam session under Duo isolation)

### DIFF
--- a/LumaCore/source/CMakeLists.txt
+++ b/LumaCore/source/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(LumaCore SHARED
     runtime/ProcessInspect.cpp
     runtime/IntegrityScanner.cpp
     runtime/LibraryInjector.cpp
+    runtime/DiversionStore.cpp
 
     patterns/ByteScan.cpp
     patterns/PatternSig.cpp

--- a/LumaCore/source/config/Settings.cpp
+++ b/LumaCore/source/config/Settings.cpp
@@ -53,6 +53,7 @@ namespace Settings {
             processExtensionX64.clear();
             onlineFixInjectEnabled = true;
             steamstubAutoEnabled = false;
+            diversionMultiInstance = true;
         }
 
         void RememberStamp(const std::filesystem::path& cfgPath)
@@ -204,6 +205,12 @@ namespace Settings {
                     steamstubAutoEnabled = *v;
             }
 
+            // [diversion]
+            if (auto dv = tbl["diversion"].as_table()) {
+                if (auto v = (*dv)["multiinstance"].value<bool>())
+                    diversionMultiInstance = *v;
+            }
+
             std::string urlsLog;
             for (const auto& u : manifestFetchUrls) {
                 if (!urlsLog.empty()) urlsLog += " | ";
@@ -222,7 +229,8 @@ namespace Settings {
                      "pattern_fetch.mirror={} manifest_fetch.urls=[{}] "
                      "manifest_fetch.timeout_sec={} manifest_fetch.trusted_hosts=[{}] "
                      "stats.enable_api={} process_extension.enabled={} "
-                     "onlinefix.inject_enabled={} steamstub.auto_enabled={}",
+                     "onlinefix.inject_enabled={} steamstub.auto_enabled={} "
+                     "diversion.multiinstance={}",
                      LevelName(logLevel), verbose ? "true" : "false",
                      static_cast<uint32_t>(luaPaths.size()),
                      patternMirror.empty() ? "<none>" : patternMirror,
@@ -232,7 +240,8 @@ namespace Settings {
                      statsEnableApi ? "true" : "false",
                      processExtensionEnabled ? "true" : "false",
                      onlineFixInjectEnabled ? "true" : "false",
-                     steamstubAutoEnabled ? "true" : "false");
+                     steamstubAutoEnabled ? "true" : "false",
+                     diversionMultiInstance ? "true" : "false");
             RememberStamp(cfgPath);
 
         } catch (const toml::parse_error& e) {

--- a/LumaCore/source/config/Settings.h
+++ b/LumaCore/source/config/Settings.h
@@ -113,6 +113,14 @@ namespace Settings {
     // override in the Lua pattern still works).
     inline bool steamstubAutoEnabled = false;
 
+    // [diversion] multiinstance
+    // Copy steamclient64.dll to an immutable content-addressed artifact
+    // (bin\lcoverlay-<sha16>.dll) shared read-only by concurrent sessions
+    // instead of overwriting a fixed lcoverlay.dll on every boot. Required
+    // for more than one simultaneous session (Duo Steam Isolation).
+    // LUMACORE_MULTIINSTANCE=0/1 overrides this at runtime.
+    inline bool diversionMultiInstance = true;
+
     // [boot]
     // When true, BootDiag::ReportMissing shows a MessageBoxA popup with
     // Steam build ID and steamclient SHA256 when IPC specs cannot be

--- a/LumaCore/source/core/entry.cpp
+++ b/LumaCore/source/core/entry.cpp
@@ -14,6 +14,7 @@
 #include "patterns/PatternFetcher.h"
 #include "runtime/DirWatch.h"
 #include "runtime/Diagnostics.h"
+#include "runtime/DiversionStore.h"
 #include "runtime/HookStatus.h"
 #include "runtime/IpcSpecLoader.h"
 #include "runtime/BootDiag.h"
@@ -127,14 +128,13 @@ namespace CoreInit {
 
         // Prepares the runtime paths and loads the hooked copy of steamclient64.dll.
         //
-        // The diversion pattern: instead of hooking the real steamclient64.dll directly,
-        // LumaCore copies it to bin\lcoverlay.dll and loads that copy. The SteamUI hook then
-        // intercepts steamui.dll's LoadModuleWithPath("steamclient64.dll") call and returns
-        // diversion_hModule, so Steam's UI layer ends up using the hooked copy transparently.
+        // With [diversion] multiinstance enabled the copy lives at
+        // bin\lcoverlay-<sha16>.dll and is never rewritten once published,
+        // so concurrent Steam sessions (Duo isolation) can load it side by
+        // side. Legacy mode keeps the fixed-name overwrite behaviour.
         //
-        // CopyFileA is retried up to 25 times (3 seconds total) because steamclient64.dll can be
-        // briefly locked by the Steam service during early startup. Same retry logic for LoadLibraryA.
-        // Returns false if either operation fails after all retries.
+        // CopyFileA/LoadLibraryA are retried because steamclient64.dll can be
+        // briefly locked by the Steam service during early startup.
         bool PrepareAndLoad()
         {
             constexpr int kCopyRetries  = 25;
@@ -156,12 +156,27 @@ namespace CoreInit {
             sprintf_s(LuaDir,          MAX_PATH, "%s\\config\\stplug-in",   SteamInstallPath);
             sprintf_s(ConfigPath,      MAX_PATH, "%s\\lumacore.toml",       SteamInstallPath);
             sprintf_s(PayloadPath,     MAX_PATH, "%s\\LumaCorePayload.dll", SteamInstallPath);
-            // ensure bin\ directory exists before copying
-            char binDir[MAX_PATH];
-            sprintf_s(binDir, MAX_PATH, "%s\\bin", SteamInstallPath);
-            CreateDirectoryA(binDir, nullptr);
-            // Retry: steamclient64.dll may be briefly locked during Steam startup
-            {
+
+            const bool multiInstance = DiversionStore::Enabled();
+
+            if (multiInstance) {
+                std::string sourceSha;
+                char artifact[MAX_PATH];
+                if (!DiversionStore::Prepare(SteamclientPath, SteamInstallPath,
+                                             artifact, MAX_PATH, &sourceSha)) {
+                    LOG_COREIN_ERROR("\"stage\" \"Diversion\" \"err\" \"prepare-fail\" \"from\" \"{}\"",
+                                     SteamclientPath);
+                    return false;
+                }
+                sprintf_s(DiversionPath, MAX_PATH, "%s", artifact);
+                HookStatus::SetBinarySnapshot(std::string(), SteamclientPath,
+                                              std::string(), DiversionPath,
+                                              sourceSha, std::string(), sourceSha);
+            } else {
+                // Legacy fixed-name path, unchanged from stock.
+                char binDir[MAX_PATH];
+                sprintf_s(binDir, MAX_PATH, "%s\\bin", SteamInstallPath);
+                CreateDirectoryA(binDir, nullptr);
                 int attempts = 0;
                 while (!CopyFileA(SteamclientPath, DiversionPath, FALSE)) {
                     if (++attempts >= kCopyRetries) {
@@ -185,6 +200,12 @@ namespace CoreInit {
             }
             LOG_COREIN_INFO("\"stage\" \"Diversion\" \"act\" \"loaded\" \"path\" \"{}\"", DiversionPath);
             HookStatus::SetDiversionState(true, "loaded");
+            HookStatus::SetDiversionDetails(true, true,
+                multiInstance ? "content-addressed-multiinstance"
+                              : "legacy-fixed-path",
+                "");
+            if (multiInstance)
+                DiversionStore::StartDeferredPrune(SteamInstallPath, DiversionPath);
             return true;
         }
 

--- a/LumaCore/source/core/entry.h
+++ b/LumaCore/source/core/entry.h
@@ -44,7 +44,11 @@ inline std::atomic<bool> g_HooksInstalled{false};
 // Runtime paths filled in by LoadDiversion() from the process working directory.
 inline char SteamInstallPath[MAX_PATH] = {};  // Steam root: the folder containing steam.exe
 inline char SteamclientPath[MAX_PATH] = {};  // <SteamInstallPath>\steamclient64.dll
-inline char DiversionPath[MAX_PATH]   = {};  // <SteamInstallPath>\bin\lcoverlay.dll (hooked copy)
+// Hooked copy of steamclient64.dll that this session loads.
+// Multi-instance mode ([diversion] multiinstance): bin\lcoverlay-<sha16>.dll,
+// an immutable content-addressed artifact shared read-only by every session.
+// Legacy mode: the fixed <SteamInstallPath>\bin\lcoverlay.dll.
+inline char DiversionPath[MAX_PATH]   = {};
 inline char LuaDir[MAX_PATH]          = {};  // <SteamInstallPath>\config\stplug-in
 inline char ConfigPath[MAX_PATH]      = {};  // <SteamInstallPath>\lumacore.toml
 inline char PayloadPath[MAX_PATH]    = {};  // <SteamInstallPath>\LumaCorePayload.dll

--- a/LumaCore/source/runtime/DiversionStore.cpp
+++ b/LumaCore/source/runtime/DiversionStore.cpp
@@ -1,0 +1,313 @@
+// LumaCore - Steam client hook layer for SteaMidra.
+// Copyright (c) 2025-2026 Midrag (https://github.com/Midrags).
+// Distributed under the GNU General Public License v3 or later.
+// See <https://www.gnu.org/licenses/> for the full license text.
+
+#include "runtime/DiversionStore.h"
+
+#include "config/Settings.h"
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace DiversionStore {
+
+    namespace {
+
+        namespace fs = std::filesystem;
+
+        constexpr int    kCopyRetries  = 25;
+        constexpr DWORD  kRetryDelayMs = 120;
+        constexpr size_t kHashChunk    = 1u << 20;
+
+        constexpr uint32_t rotr(uint32_t v, unsigned n) {
+            return (v >> n) | (v << (32 - n));
+        }
+
+        constexpr uint32_t kShaK[64] = {
+            0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+            0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+            0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+            0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+            0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+            0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+            0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+            0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+            0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+            0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+            0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
+            0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+            0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
+            0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+            0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+            0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+        };
+
+        class Sha256 {
+        public:
+            Sha256() { Reset(); }
+
+            void Reset() {
+                h_[0] = 0x6a09e667u; h_[1] = 0xbb67ae85u;
+                h_[2] = 0x3c6ef372u; h_[3] = 0xa54ff53au;
+                h_[4] = 0x510e527fu; h_[5] = 0x9b05688cu;
+                h_[6] = 0x1f83d9abu; h_[7] = 0x5be0cd19u;
+                total_ = 0;
+                used_  = 0;
+            }
+
+            void Update(const uint8_t* data, size_t n) {
+                total_ += n;
+                while (n > 0) {
+                    if (used_ == 0 && n >= sizeof(buf_)) {
+                        Transform(data);
+                        data += sizeof(buf_);
+                        n    -= sizeof(buf_);
+                        continue;
+                    }
+                    const size_t take = (n < sizeof(buf_) - used_)
+                                            ? n : (sizeof(buf_) - used_);
+                    std::memcpy(buf_ + used_, data, take);
+                    used_ += take;
+                    data  += take;
+                    n     -= take;
+                    if (used_ == sizeof(buf_)) {
+                        Transform(buf_);
+                        used_ = 0;
+                    }
+                }
+            }
+
+            std::string Final() {
+                const uint64_t bitLen = total_ * 8ull;
+                const uint8_t  pad    = 0x80;
+                Update(&pad, 1);
+                const uint8_t zero = 0;
+                while (used_ != 56) Update(&zero, 1);
+                uint8_t lenBytes[8];
+                for (int i = 0; i < 8; ++i)
+                    lenBytes[i] =
+                        static_cast<uint8_t>(bitLen >> (56 - i * 8));
+                Update(lenBytes, 8);
+
+                static const char kHex[] = "0123456789abcdef";
+                std::string out;
+                out.reserve(64);
+                for (int i = 0; i < 8; ++i)
+                    for (int b = 3; b >= 0; --b) {
+                        out += kHex[(h_[i] >> (b * 8 + 4)) & 0xF];
+                        out += kHex[(h_[i] >> (b * 8)) & 0xF];
+                    }
+                return out;
+            }
+
+        private:
+            void Transform(const uint8_t* p) {
+                uint32_t w[64];
+                for (int i = 0; i < 16; ++i)
+                    w[i] = (static_cast<uint32_t>(p[i * 4])     << 24) |
+                           (static_cast<uint32_t>(p[i * 4 + 1]) << 16) |
+                           (static_cast<uint32_t>(p[i * 4 + 2]) <<  8) |
+                            static_cast<uint32_t>(p[i * 4 + 3]);
+                for (int i = 16; i < 64; ++i) {
+                    const uint32_t s0 =
+                        rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+                    const uint32_t s1 =
+                        rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+                    w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+                }
+                uint32_t a = h_[0], b = h_[1], c = h_[2], d = h_[3];
+                uint32_t e = h_[4], f = h_[5], g = h_[6], h = h_[7];
+                for (int i = 0; i < 64; ++i) {
+                    const uint32_t S1  = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+                    const uint32_t ch  = (e & f) ^ (~e & g);
+                    const uint32_t t1  = h + S1 + ch + kShaK[i] + w[i];
+                    const uint32_t S0  = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+                    const uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+                    const uint32_t t2  = S0 + maj;
+                    h = g; g = f; f = e; e = d + t1;
+                    d = c; c = b; b = a; a = t1 + t2;
+                }
+                h_[0] += a; h_[1] += b; h_[2] += c; h_[3] += d;
+                h_[4] += e; h_[5] += f; h_[6] += g; h_[7] += h;
+            }
+
+            uint32_t h_[8];
+            uint64_t total_;
+            size_t   used_;
+            uint8_t  buf_[64];
+        };
+
+        bool HashFile(const std::string& path, std::string* hexOut,
+                      unsigned long long* sizeOut) {
+            HANDLE h = CreateFileA(path.c_str(), GENERIC_READ,
+                                   FILE_SHARE_READ | FILE_SHARE_WRITE |
+                                       FILE_SHARE_DELETE,
+                                   nullptr, OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (h == INVALID_HANDLE_VALUE) return false;
+
+            LARGE_INTEGER sz{};
+            if (!GetFileSizeEx(h, &sz) || sz.QuadPart < 0) {
+                CloseHandle(h);
+                return false;
+            }
+
+            Sha256 sha;
+            std::string chunk(kHashChunk, '\0');
+            for (;;) {
+                DWORD got = 0;
+                if (!ReadFile(h, chunk.data(),
+                              static_cast<DWORD>(chunk.size()), &got,
+                              nullptr)) {
+                    CloseHandle(h);
+                    return false;
+                }
+                if (got == 0) break;
+                sha.Update(reinterpret_cast<const uint8_t*>(chunk.data()),
+                           got);
+            }
+            CloseHandle(h);
+
+            if (hexOut)  *hexOut  = sha.Final();
+            if (sizeOut) *sizeOut = static_cast<unsigned long long>(sz.QuadPart);
+            return true;
+        }
+
+        enum class PublishKind { Published, LostRace, Failed };
+
+        // Temp name carries pid + tick so simultaneous boots never share a
+        // swap file. Losing the rename just means the other boot published
+        // identical bytes first.
+        PublishKind PublishArtifact(const char* steamclientPath,
+                                    const fs::path& binDir,
+                                    const std::string& shortHash) {
+            const fs::path finalPath =
+                binDir / ("lcoverlay-" + shortHash + ".dll");
+            const fs::path temp =
+                binDir / ("lcoverlay-" + shortHash + "-" +
+                          std::to_string(GetCurrentProcessId()) + "-" +
+                          std::to_string(GetTickCount()) + ".tmp");
+
+            int attempts = 0;
+            while (!CopyFileA(steamclientPath, temp.string().c_str(), FALSE)) {
+                if (++attempts >= kCopyRetries) return PublishKind::Failed;
+                Sleep(kRetryDelayMs);
+            }
+
+            if (!MoveFileExA(temp.string().c_str(), finalPath.string().c_str(),
+                             MOVEFILE_REPLACE_EXISTING)) {
+                DeleteFileA(temp.string().c_str());
+                return PublishKind::LostRace;
+            }
+            return PublishKind::Published;
+        }
+
+        void PruneStaleArtifacts(const std::string& binDirStr,
+                                 const std::string& keepName) {
+            try {
+                std::error_code ec;
+                const fs::path binDir(binDirStr);
+                for (fs::directory_iterator it(binDir, ec), end;
+                     !ec && it != end; it.increment(ec)) {
+                    if (ec) break;
+                    const std::string name = it->path().filename().string();
+                    if (name == keepName) continue;
+                    if (name.rfind("lcoverlay", 0) != 0) continue;
+                    if (name.size() <= 4 ||
+                        (name.compare(name.size() - 4, 4, ".dll") != 0 &&
+                         name.compare(name.size() - 4, 4, ".tmp") != 0))
+                        continue;
+                    // Fails on anything another process still maps.
+                    DeleteFileA(it->path().string().c_str());
+                }
+            } catch (...) {
+            }
+        }
+
+        DWORD WINAPI PruneThread(LPVOID param) {
+            std::unique_ptr<std::string> work(
+                static_cast<std::string*>(param));
+            if (!work) return 0;
+            Sleep(3000);
+            const size_t sep = work->find('\n');
+            if (sep == std::string::npos) return 0;
+            PruneStaleArtifacts(work->substr(0, sep), work->substr(sep + 1));
+            return 0;
+        }
+
+    }  // namespace
+
+    bool Enabled() {
+        char env[8] = {};
+        const DWORD n = GetEnvironmentVariableA("LUMACORE_MULTIINSTANCE",
+                                                env, sizeof(env));
+        if (n > 0 && n < sizeof(env)) {
+            if (env[0] == '0') return false;
+            if (env[0] == '1') return true;
+        }
+        return Settings::diversionMultiInstance;
+    }
+
+    bool Prepare(const char* steamclientPath,
+                 const char* steamInstallPath,
+                 char* outArtifactPath, DWORD outArtifactCch,
+                 std::string* outSourceSha) {
+        if (!steamclientPath || !steamInstallPath ||
+            !outArtifactPath || outArtifactCch == 0)
+            return false;
+
+        std::error_code ec;
+        const fs::path binDir = fs::path(steamInstallPath) / "bin";
+        fs::create_directories(binDir, ec);
+        if (ec) return false;
+
+        std::string srcSha;
+        unsigned long long srcSize = 0;
+        if (!HashFile(steamclientPath, &srcSha, &srcSize))
+            return false;
+
+        const std::string shortHash = srcSha.substr(0, 16);
+        const fs::path finalPath =
+            binDir / ("lcoverlay-" + shortHash + ".dll");
+
+        // Re-hash whatever sits at the final path: reuses it only when it
+        // really is a copy of the live source dll, republishes otherwise.
+        auto validExisting = [&]() -> bool {
+            std::string curSha;
+            unsigned long long curSize = 0;
+            if (!HashFile(finalPath.string(), &curSha, &curSize))
+                return false;
+            return curSize == srcSize && curSha == srcSha;
+        };
+
+        if (!validExisting())
+            PublishArtifact(steamclientPath, binDir, shortHash);
+
+        if (!validExisting())
+            return false;
+
+        strncpy_s(outArtifactPath, outArtifactCch,
+                  finalPath.string().c_str(), _TRUNCATE);
+        if (outSourceSha) *outSourceSha = srcSha;
+        return true;
+    }
+
+    void StartDeferredPrune(const char* steamInstallPath,
+                            const char* currentArtifactPath) {
+        if (!steamInstallPath || !currentArtifactPath) return;
+        const std::string binDir =
+            (fs::path(steamInstallPath) / "bin").string();
+        auto work = new std::string(binDir + "\n" + currentArtifactPath);
+        HANDLE h = CreateThread(nullptr, 0, PruneThread, work, 0, nullptr);
+        if (!h) {
+            delete work;
+            return;
+        }
+        CloseHandle(h);
+    }
+
+}  // namespace DiversionStore

--- a/LumaCore/source/runtime/DiversionStore.h
+++ b/LumaCore/source/runtime/DiversionStore.h
@@ -1,0 +1,35 @@
+// LumaCore - Steam client hook layer for SteaMidra.
+// Copyright (c) 2025-2026 Midrag (https://github.com/Midrags).
+// Distributed under the GNU General Public License v3 or later.
+// See <https://www.gnu.org/licenses/> for the full license text.
+
+#ifndef DIVERSION_STORE_H
+#define DIVERSION_STORE_H
+
+// Content-addressed diversion copies for concurrent Steam sessions. Each
+// build of steamclient64.dll gets its own immutable file under bin\ instead
+// of every boot overwriting the fixed bin\lcoverlay.dll, which fails with
+// ERROR_SHARING_VIOLATION while another session has it loaded.
+
+#include <windows.h>
+#include <string>
+
+namespace DiversionStore {
+
+    // LUMACORE_MULTIINSTANCE=0/1 wins over [diversion] multiinstance.
+    bool Enabled();
+
+    // Ensures a byte-exact copy of steamclientPath exists under bin\, named
+    // after its sha256, and returns its full path in outArtifactPath.
+    bool Prepare(const char* steamclientPath,
+                 const char* steamInstallPath,
+                 char* outArtifactPath, DWORD outArtifactCch,
+                 std::string* outSourceSha);
+
+    // Deletes stale lcoverlay* files no process keeps mapped.
+    void StartDeferredPrune(const char* steamInstallPath,
+                            const char* currentArtifactPath);
+
+}  // namespace DiversionStore
+
+#endif // DIVERSION_STORE_H

--- a/LumaCore/source/runtime/HookStatus.cpp
+++ b/LumaCore/source/runtime/HookStatus.cpp
@@ -206,6 +206,9 @@ namespace HookStatus {
             out += "  \"lumacore_version\": \"";
             out += JsonEscape(kLumaCoreVersion);
             out += "\",\n";
+            out += "  \"pid\": ";
+            out += std::to_string(static_cast<unsigned long>(::GetCurrentProcessId()));
+            out += ",\n";
             out += "  \"build_config\": \"";
             out += JsonEscape(kBuildConfig);
             out += "\",\n";
@@ -599,6 +602,66 @@ namespace HookStatus {
             return out;
         }
 
+        // Drops status.<pid>.json files whose process no longer exists.
+        void PruneDeadSessionFiles(const std::filesystem::path& dir) {
+            static std::atomic<DWORD> s_lastPruneMs{0};
+            const DWORD now = GetTickCount();
+            const DWORD last = s_lastPruneMs.load(std::memory_order_relaxed);
+            if (last && now - last < 60000) return;
+            s_lastPruneMs.store(now, std::memory_order_relaxed);
+
+            std::error_code ec;
+            for (std::filesystem::directory_iterator it(dir, ec), end;
+                 !ec && it != end; it.increment(ec)) {
+                if (ec) break;
+                const std::string name = it->path().filename().string();
+                if (name.rfind("status.", 0) != 0) continue;
+                const size_t dot = name.find('.', 7);
+                if (dot == std::string::npos) continue;
+                const std::string mid = name.substr(7, dot - 7);
+                bool numeric = !mid.empty();
+                for (const char c : mid)
+                    if (c < '0' || c > '9') { numeric = false; break; }
+                if (!numeric) continue;
+
+                const DWORD pid =
+                    static_cast<DWORD>(std::strtoul(mid.c_str(), nullptr, 10));
+                if (pid == ::GetCurrentProcessId()) continue;
+
+                HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                       FALSE, pid);
+                if (h) {
+                    CloseHandle(h);   // session still alive
+                    continue;
+                }
+                if (GetLastError() != ERROR_INVALID_PARAMETER)
+                    continue;         // alive but not inspectable: keep
+
+                std::error_code rmEc;
+                std::filesystem::remove(it->path(), rmEc);
+            }
+        }
+
+        // Per-instance copy of the snapshot, next to the shared status.json.
+        void WritePerInstanceMirror(const std::filesystem::path& dir,
+                                    const std::string& body) {
+            const std::string pid =
+                std::to_string(static_cast<unsigned long>(::GetCurrentProcessId()));
+            const std::filesystem::path target =
+                dir / ("status." + pid + ".json");
+            std::filesystem::path tmp = target;
+            tmp += "." + pid + ".tmp";
+
+            {
+                std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+                if (!f) return;
+                f.write(body.data(), static_cast<std::streamsize>(body.size()));
+                if (!f) return;
+            }
+            MoveFileExA(tmp.string().c_str(), target.string().c_str(),
+                        MOVEFILE_REPLACE_EXISTING);
+        }
+
         bool WriteBodyAtomic(const std::string& body) {
             static std::atomic<DWORD> s_lastFailMs{0};
             static constexpr DWORD kCooldownMs = 5000;
@@ -618,10 +681,13 @@ namespace HookStatus {
                 LOG_WARN("HookStatus: create_directories failed: {}", ec.message());
                 return false;
             }
+            PruneDeadSessionFiles(dir);
 
             std::filesystem::path target = dir / "status.json";
             std::filesystem::path tmp    = target;
-            tmp += ".tmp";
+            tmp += "." +
+                   std::to_string(static_cast<unsigned long>(::GetCurrentProcessId())) +
+                   ".tmp";
 
             std::string narrowTmp    = tmp.string();
             std::string narrowTarget = target.string();
@@ -661,6 +727,7 @@ namespace HookStatus {
                 return false;
             }
             s_lastFailMs.store(0, std::memory_order_relaxed);
+            WritePerInstanceMirror(dir, body);
             return true;
         }
 


### PR DESCRIPTION
## Problem

With Duo Steam Isolation (multiple concurrent steam.exe from one install), LumaCore fails to initialize in the second session. Diversion::PrepareAndLoad() overwrites the fixed <Steam>\bin\lcoverlay.dll on every boot; while session 1 keeps that module mapped, Windows rejects the overwrite with ERROR_SHARING_VIOLATION (32). The 25x120ms retry loop cannot outlast a mapped module, so boot aborts.

The global lumacore\status.json / status.json.tmp pair has the same single-instance assumption: sessions race on the same swap file and a healthy instance overwrites a failed instance's diagnostics.

## Fix

Turns the diversion copy into an immutable, content-addressed artifact:

`
<Steam>\bin\lcoverlay-<first16-hex-of-sha256(steamclient64.dll)>.dll
`

- Published once via per-pid temp file + MOVEFILE_REPLACE_EXISTING; racing boots converge (loser validates identical bytes and reuses).
- Reuse requires re-hashing the existing file, so truncated/tampered leftovers are transparently republished.
- Never rewritten while any process may have it mapped; Steam updates naturally produce a new artifact name.
- Deferred attempt-based prune sweeps stale artifacts/temp files (DeleteFileA simply fails on anything another session keeps mapped).
- New unit: untime/DiversionStore.{h,cpp} (streaming SHA-256 + protocol, self-contained).

Status side: "pid" field added, swap temps are now status.json.<pid>.tmp, each instance also writes lumacore\status.<pid>.json, and dead-session status files are pruned (throttled). SteaMidra keeps reading the global status.json unchanged.

SetBinarySnapshot() was previously never called; it is now wired so diversion_path/diversion_file_sha report real values.

## Config / rollback

`	oml
[diversion]
multiinstance = true   # default; false restores stock fixed-name behaviour
`

Environment override without rebuilding: LUMACORE_MULTIINSTANCE=0|1.

## Verification

- Standalone test of the store (publish / reuse while locked with loader-like sharing semantics / corruption recovery): PASS; computed sha256 matches Windows CNG (GetFileHash) on a 26MB steamclient64.dll.
- Live run, two simultaneous isolated Steam sessions: both reach hooks_complete with 42 hooks and 274 lua depots, sharing the same artifact:

`
--- status.<pid1>.json ---            --- status.<pid2>.json ---
startup_phase: hooks_complete         startup_phase: hooks_complete
diversion_strategy:
  content-addressed-multiinstance     content-addressed-multiinstance
diversion_path: bin\lcoverlay-86112382982fa855.dll (both)
`

Closes the multi-instance failure mode described above. Happy to adjust naming/flag defaults if maintainers prefer a different contract.