### PR TITLE
Fix Google Drive save sync reporting success while uploading nothing

### DIFF
--- a/build_sff.spec
+++ b/build_sff.spec
@@ -108,6 +108,12 @@ if os.path.exists(os.path.join(spec_root, 'SFF.png')):
 if os.path.exists(os.path.join(spec_root, 'SFF.ico')):
     datas.append(('SFF.ico', '.'))
 
+# Ludusavi save-path manifest used by Cloud Saves. Without it the custom
+# save-path scan silently finds nothing and only Steam userdata is backed up.
+sff_data_dir = os.path.join(spec_root, 'sff', 'data')
+if os.path.isdir(sff_data_dir):
+    datas.append((sff_data_dir, 'sff/data'))
+
 # Include all_games.txt for offline game name resolution in Cloud Saves
 all_games_txt = os.path.join(spec_root, 'all_games.txt')
 if os.path.exists(all_games_txt):

--- a/build_sff_gui.spec
+++ b/build_sff_gui.spec
@@ -70,6 +70,12 @@ fallback_db = os.path.join(spec_root, 'sff', 'lua', 'fallback_depotkeys.json')
 if os.path.exists(fallback_db):
     datas.append((fallback_db, 'sff/lua'))
 
+# Ludusavi save-path manifest used by Cloud Saves. Without it the custom
+# save-path scan silently finds nothing and only Steam userdata is backed up.
+sff_data_dir = os.path.join(spec_root, 'sff', 'data')
+if os.path.isdir(sff_data_dir):
+    datas.append((sff_data_dir, 'sff/data'))
+
 # Include all_games.txt for offline game name resolution in Cloud Saves
 all_games_txt = os.path.join(spec_root, 'all_games.txt')
 if os.path.exists(all_games_txt):

--- a/build_sff_linux.spec
+++ b/build_sff_linux.spec
@@ -75,6 +75,12 @@ fallback_db = os.path.join(spec_root, 'sff', 'lua', 'fallback_depotkeys.json')
 if os.path.exists(fallback_db):
     datas.append((fallback_db, 'sff/lua'))
 
+# Ludusavi save-path manifest used by Cloud Saves. Without it the custom
+# save-path scan silently finds nothing and only Steam userdata is backed up.
+sff_data_dir = os.path.join(spec_root, 'sff', 'data')
+if os.path.isdir(sff_data_dir):
+    datas.append((sff_data_dir, 'sff/data'))
+
 c_dir = os.path.join(spec_root, 'c')
 if os.path.exists(c_dir):
     datas.append((c_dir, 'c'))

--- a/sff/cloud/cloud_save_paths.py
+++ b/sff/cloud/cloud_save_paths.py
@@ -49,7 +49,9 @@ _STEAM_ID_RE = re.compile(r"^  steam:\s*?\n    id:\s*(\d+)", re.MULTILINE)
 
 
 def _manifest_path() -> Path:
-    return Path(__file__).resolve().parent / "data" / "manifest.yaml"
+    # The manifest ships in sff/data/, not next to this module. Frozen builds
+    # keep the same layout under _internal/, so parent.parent works for both.
+    return Path(__file__).resolve().parent.parent / "data" / "manifest.yaml"
 
 
 def _load_manifest_index() -> None:

--- a/sff/cloud/cloud_saves.py
+++ b/sff/cloud/cloud_saves.py
@@ -1173,6 +1173,7 @@ def backup_save_location_gdrive(entry, service, backup_root_id, log_func=None, f
     local_fc = dict(folder_cache) if folder_cache is not None else {}
 
     meta_sources = []
+    all_uploads_ok = True
     try:
         game_folder_id = get_or_create_folder(service, label, backup_root_id)
         if not game_folder_id:
@@ -1184,8 +1185,11 @@ def backup_save_location_gdrive(entry, service, backup_root_id, log_func=None, f
             if not src or not src.exists():
                 log(f"  [!] Source not found: {source.get('source_path')}")
                 continue
-            upload_folder(service, src, game_folder_id, log_func=log,
-                          folder_cache=local_fc, drive_folder_name=source.get("storage_path", ""))
+            if not upload_folder(service, src, game_folder_id, log_func=log,
+                                 folder_cache=local_fc,
+                                 drive_folder_name=source.get("storage_path", "")):
+                all_uploads_ok = False
+                log(f"  [FAIL] Upload incomplete: {src}")
             saved_source = dict(source)
             saved_source["source_path"] = str(src)
             meta_sources.append(saved_source)
@@ -1193,13 +1197,20 @@ def backup_save_location_gdrive(entry, service, backup_root_id, log_func=None, f
         if not meta_sources:
             log(f"  [FAIL] No valid sources to upload: {label}")
             return False
+        if not all_uploads_ok:
+            # Do not stamp a fresh backup time over a partial upload; the
+            # metadata would claim a good backup that is not on Drive.
+            return False
 
         meta = _entry_meta(entry, meta_sources)
         tmp = Path(tempfile.mkdtemp(prefix="steamidra_meta_"))
         try:
             meta_file = tmp / "steamidra_meta.json"
             meta_file.write_text(json.dumps(meta, indent=2), encoding="utf-8")
-            upload_file_replace(service, meta_file, game_folder_id, log_func=log)
+            if not upload_file_replace(service, meta_file, game_folder_id, log_func=log,
+                                       force=True):
+                log(f"  [FAIL] Could not write metadata for {label}")
+                return False
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
 

--- a/sff/cloud/google_drive.py
+++ b/sff/cloud/google_drive.py
@@ -175,22 +175,39 @@ def get_or_create_folder(service, name, parent_id="root"):
     return None
 
 
+def _local_md5(path):
+    """MD5 of a local file, or None if it cannot be read."""
+    import hashlib
+    h = hashlib.md5()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
 def _list_folder_index(service, parent_id):
-    """Return {name: (file_id, size)} for all non-trashed files in a Drive folder."""
+    """Return {name: {"id", "size", "md5"}} for non-trashed files in a Drive folder."""
     index = {}
     page_token = None
     while True:
         try:
             params = {
                 "q": f"'{parent_id}' in parents and trashed=false and mimeType!='application/vnd.google-apps.folder'",
-                "fields": "nextPageToken,files(id,name,size)",
+                "fields": "nextPageToken,files(id,name,size,md5Checksum)",
                 "pageSize": 1000,
             }
             if page_token:
                 params["pageToken"] = page_token
             res = service.files().list(**params).execute()
             for f in res.get("files", []):
-                index[f["name"]] = (f["id"], int(f.get("size", -1)))
+                index[f["name"]] = {
+                    "id": f["id"],
+                    "size": int(f.get("size", -1)),
+                    "md5": f.get("md5Checksum") or "",
+                }
             page_token = res.get("nextPageToken")
             if not page_token:
                 break
@@ -200,8 +217,17 @@ def _list_folder_index(service, parent_id):
     return index
 
 
-def _upload_file_smart(service, local_path, parent_id, existing_index, log_func=None):
-    """Upload a single file using smart sync: skip if same size, update if changed, create if new."""
+def _upload_file_smart(service, local_path, parent_id, existing_index, log_func=None,
+                       force=False):
+    """Upload a single file: skip only when the content hash matches, else update/create.
+
+    Size alone is not a change signal. Plenty of save files are rewritten in
+    place at a constant length (fixed-width slots, container formats, the
+    backup metadata JSON with its fixed-length timestamp), so a size check
+    marks them unchanged forever and the remote copy silently goes stale.
+    Drive hands back md5Checksum for uploaded binaries, so compare that and
+    fall back to size only when the checksum is unavailable.
+    """
     from googleapiclient.http import MediaFileUpload
     local_path = Path(local_path)
     if not local_path.exists():
@@ -209,16 +235,23 @@ def _upload_file_smart(service, local_path, parent_id, existing_index, log_func=
     name = local_path.name
     local_size = local_path.stat().st_size
     existing = existing_index.get(name)
-    if existing and existing[1] == local_size:
-        if log_func:
-            log_func(f"  Skipped (unchanged): {name}")
-        return True
+    if existing and not force:
+        remote_md5 = existing.get("md5") or ""
+        if remote_md5:
+            if _local_md5(local_path) == remote_md5:
+                if log_func:
+                    log_func(f"  Skipped (unchanged): {name}")
+                return True
+        elif existing.get("size") == local_size:
+            if log_func:
+                log_func(f"  Skipped (unchanged): {name}")
+            return True
     import time as _time
     for _attempt in range(4):
         try:
             media = MediaFileUpload(str(local_path), resumable=False)
             if existing:
-                fid = existing[0]
+                fid = existing["id"]
                 service.files().update(fileId=fid, media_body=media).execute()
                 if log_func:
                     log_func(f"  Updated: {name}")
@@ -280,10 +313,11 @@ def upload_file(service, local_path, parent_id, log_func=None):
     return False
 
 
-def upload_file_replace(service, local_path, parent_id, log_func=None):
+def upload_file_replace(service, local_path, parent_id, log_func=None, force=False):
     """Upload or replace one file by name in parent_id."""
     index = _list_folder_index(service, parent_id)
-    return _upload_file_smart(service, local_path, parent_id, index, log_func=log_func)
+    return _upload_file_smart(service, local_path, parent_id, index, log_func=log_func,
+                              force=force)
 
 
 def upload_folder(service, local_folder, parent_id, log_func=None, folder_cache=None, drive_folder_name=None):
@@ -410,7 +444,10 @@ def write_backup_meta(service, backup_root_id, location, folder_name, meta, log_
     try:
         meta_path = tmp / _meta_file_name(str(location or ""), str(folder_name or ""))
         meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
-        return bool(upload_file_replace(service, meta_path, loc_root, log_func=log_func))
+        # Always rewrite the metadata; "backed_up_at" is what tells the user
+        # when the last sync ran, so it must never be skipped as unchanged.
+        return bool(upload_file_replace(service, meta_path, loc_root, log_func=log_func,
+                                        force=True))
     finally:
         try:
             import shutil

--- a/sff/gui/main_window.py
+++ b/sff/gui/main_window.py
@@ -1852,6 +1852,7 @@ class SFFMainWindow(QMainWindow):
             return
         provider = cfg.get('provider', 'local').lower()
         backed_up = 0
+        failed = 0
         if provider == 'local':
             dest_path = cfg.get('dest_path', '')
             if not dest_path:
@@ -1884,28 +1885,65 @@ class SFFMainWindow(QMainWindow):
                     except Exception:
                         pass
         elif provider == 'gdrive_api':
+            import threading
             from sff.cloud.google_drive import get_service, get_backup_root, is_authenticated
             from concurrent.futures import ThreadPoolExecutor, as_completed
             if not is_authenticated():
+                logger.debug('Save watcher: Google Drive not connected, nothing backed up')
                 return
             svc = get_service()
             if not svc:
+                logger.debug('Save watcher: could not connect to Google Drive')
                 return
             root_id = get_backup_root(svc)
             if not root_id:
+                logger.debug('Save watcher: could not open the Drive backup root')
                 return
             folder_cache = {}
+            lock = threading.Lock()
+            local = threading.local()
+
+            def _backup_one(entry):
+                # One Drive service per worker thread; the client is not
+                # thread-safe and rebuilding it per entry is wasted work.
+                thread_svc = getattr(local, 'svc', None)
+                if thread_svc is None:
+                    thread_svc = get_service()
+                    local.svc = thread_svc
+                if thread_svc is None:
+                    logger.debug('Save watcher: %s skipped, no Drive service',
+                                 entry.get('label', '?'))
+                    return False
+                lines = []
+                with lock:
+                    thread_cache = dict(folder_cache)
+                ok = backup_save_location_gdrive(
+                    entry, thread_svc, root_id,
+                    log_func=lines.append, folder_cache=thread_cache,
+                )
+                with lock:
+                    folder_cache.update(thread_cache)
+                if not ok:
+                    # Without this the watcher reports success for entries
+                    # whose uploads all failed.
+                    logger.debug('Save watcher: %s failed\n%s',
+                                 entry.get('label', '?'), '\n'.join(lines))
+                return ok
+
             with ThreadPoolExecutor(max_workers=10) as ex:
-                futures = {ex.submit(backup_save_location_gdrive, e, get_service(), root_id,
-                                     None, dict(folder_cache)): e for e in entries}
+                futures = {ex.submit(_backup_one, e): e for e in entries}
                 for fut in as_completed(futures):
                     try:
                         if fut.result():
                             backed_up += 1
+                        else:
+                            failed += 1
                     except Exception:
-                        pass
-        if backed_up:
-            logger.debug('Save watcher (%s): backed up %d entries', provider, backed_up)
+                        failed += 1
+                        logger.debug('Save watcher entry error', exc_info=True)
+        if backed_up or failed:
+            logger.debug('Save watcher (%s): %d entry(s) synced, %d failed',
+                         provider, backed_up, failed)
 
     # ── About ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Auto-backup to Google Drive logged a successful sync every 10 minutes for two days straight while nothing new actually landed on Drive. Three separate bugs stack up here; the last one is what hides the other two.

Reproduced from a 6.6.6 debug log: 312 watcher cycles, every one of them reporting `Save watcher (gdrive_api): backed up 56 entries`, each finishing 11-15 seconds after firing. 56 save folders cannot upload in 11 seconds — that is a list-and-skip pass moving zero bytes.

### 1. The Ludusavi manifest is never loaded

```
[DEBU] sff.cloud.cloud_save_paths — manifest.yaml not found at
C:\...\SteaMidra\_internal\sff\cloud\data\manifest.yaml
```

`_manifest_path()` resolved to `sff/cloud/data/manifest.yaml`, but the manifest ships in `sff/data/manifest.yaml` (as the README says). On top of that, none of `build_sff.spec`, `build_sff_gui.spec`, `build_sff_linux.spec` bundled `sff/data`, so the file is absent from installed builds regardless — `find` over an installed 6.6.6 turns up no `manifest.yaml` anywhere.

Consequence: `get_save_paths()` returns `[]` for every app id, the Ludusavi block in `scan_all_save_locations()` (cloud_saves.py:843) contributes nothing, and only Steam userdata plus emulator roots get backed up. Any game that saves under Documents, AppData or its own install folder is silently skipped, which is exactly the case the feature was added for.

Fixed the path and added `sff/data` to all three specs. The index goes from 0 to 48525 steam id blocks; Lies of P now resolves to `LiesofP/Saved/SaveGames/*` as intended.

### 2. Drive sync decides "unchanged" from file size alone

`_upload_file_smart`:

```python
existing = existing_index.get(name)
if existing and existing[1] == local_size:
    log_func(f"  Skipped (unchanged): {name}")
    return True
```

Name plus byte size matching means skip — no mtime, no checksum. A save file rewritten in place at a constant length (fixed-width slots, container formats) is treated as unchanged forever and the Drive copy goes stale without a word. Worth noting the local provider gets this right (`_copy_source_to_dest` checks size **and** mtime) and rclone handles it itself; the Drive path is the only one comparing size alone.

It also breaks the timestamp users read to judge whether backups are running. `_entry_meta` writes `backed_up_at` as `datetime.now().isoformat(timespec="seconds")`, always 19 characters, so `steamidra_meta.json` is byte-identical in length every run, gets skipped, and the restore list keeps showing whenever the first backup happened.

`_list_folder_index` now requests `md5Checksum` and `_upload_file_smart` compares hashes, falling back to size only when Drive returns no checksum. Metadata writes pass `force=True` and skip the comparison outright.

### 3. Failures cannot be observed

`backup_save_location_gdrive` threw away `upload_folder`'s return value and returned `True` unconditionally, and the watcher called it with `log_func=None`, so `log` was `lambda m: None` and every `[FAIL]` line went nowhere. An entry whose uploads all failed with 403s still counted toward "backed up N entries". There is no way to tell a working sync from a completely broken one.

Failures now propagate, a partial upload no longer stamps a fresh `backed_up_at` over content that is not on Drive, and the watcher logs the per-entry failure lines.

Also in the watcher: `get_service()` was called once per entry inside the submitting thread (56 Drive clients built serially before any work started), and each worker got `dict(folder_cache)` from an empty dict that was never written back, so the cache never accumulated. Now one service per worker thread and a shared cache under a lock.

### Testing

- `_manifest_path()` resolves and indexes the real 18 MB manifest; spot-checked resolution for Lies of P (app 1627720).
- `_upload_file_smart` covered against a stubbed Drive client: same size with different content uploads (the case that regressed), identical content skips, `force=True` uploads anyway, missing checksum falls back to the size comparison, unknown name creates.
- All touched files parse; no other caller of `_list_folder_index` exists outside `google_drive.py`.

I have not rebuilt the installer, so the spec change is verified by reading only — worth a check that `sff/data/manifest.yaml` lands in `_internal/sff/data/` in the next build, since the 18 MB manifest does add to the package size.
