### PR TITLE
fix(native): handle zip-framed chunk and deque ContentServer pool

### DIFF
--- a/sff/downloads/native_downloader.py
+++ b/sff/downloads/native_downloader.py
@@ -229,7 +229,13 @@ def _decompress_chunk(data: bytes) -> bytes:
         return _decompress_vz1(data)
     if data[:4] == b"VSZa":
         return _decompress_vzstd(data)
-    raise ValueError(f"unknown chunk magic: {data[:4].hex()}")
+    if data[:4] == b"PK\x03\x04":
+        # zip-framed chunk (e.g. shared redist depots like 228990): single
+        # entry 'z' holds the payload
+        with zipfile.ZipFile(io.BytesIO(data)) as _zf:
+            return _zf.read(_zf.namelist()[0])
+    # no known magic = stored uncompressed; caller's SHA1 check validates
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -279,13 +285,24 @@ def _resolve_request_code(
 
 
 def _get_cdn_servers(cdn_client) -> list:
+    # steam lib returns a deque of ContentServer objects (not a list of dicts)
+    # — normalize both shapes; a single-host pool got us IP-throttled mid-run
     try:
         raw = cdn_client.servers
-        if isinstance(raw, list):
-            return raw
+        out = []
+        for s in (raw or []):
+            if isinstance(s, dict):
+                host = s.get("host", "")
+                https = s.get("https_support") == "mandatory"
+            else:
+                host = getattr(s, "host", "") or ""
+                https = bool(getattr(s, "https", False))
+            if host:
+                out.append({"host": host, "https_support": "mandatory" if https else ""})
+        if out:
+            return out
     except Exception:
         pass
-    # Fallback: well-known Steam CDN host
     return [{"host": "steampipe.akamaized.net"}]
 
 


### PR DESCRIPTION
Two native downloader fixes that hit every user after the steam lib update.

**1. zip-framed chunk `PK` (depot 228990 etc.)**
Some shared redist depots (e.g. `228990 _CommonRedist/DirectX/Jun2010`) store chunks as `PK\x03\x04` zip with a single entry `z` instead of `VZa`/`VSZa`. `_decompress_chunk` raised `ValueError: unknown chunk magic 504b0304` and the whole depot failed `0/203` (Sekiro repro: every run, every mirror). Fix unzips the single entry; unknown magic falls back to stored-uncompressed with caller SHA1 as guard — matches what Steam does.

**2. `deque[ContentServer]` pool**
`steam 2.x` (`solsticegamestudios`) returns `deque[ContentServer(host, https)]`, not `list[dict]`. `isinstance(raw, list)` collapsed the `~17` Valve edges to the single `steampipe` fallback and got throttled mid-download. Fix normalizes both shapes to `[{"host","https_support"}]`.

Verified on SteaMidra 6.6.6 against Sekiro (`228990 203/203` after fix) and full `228990` SHA1 repro; no wrapper-specific code.