### PR TITLE
Fix IClientRemoteStorage FileExists hook ABI for current Steam

### DIFF
--- a/LumaCore/source/hooks/client/IPCBus.cpp
+++ b/LumaCore/source/hooks/client/IPCBus.cpp
@@ -131,16 +131,15 @@ namespace {
         }
     };
 
-    LM_HOOK(IClientRemoteStorage_FileExists, bool, void* pThis, const char* pchFile)
+    LM_HOOK(IClientRemoteStorage_FileExists, bool,
+              void* pThis, AppId_t appId, uint32_t fileRoot, const char* pchFile)
     {
-        uint32_t* pAppId = reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(pThis) + 0x38);
-        uint32_t saved = *pAppId;
         AppId_t real = SteamCapture::ActiveRouteRealAppId();
-        if (real && saved == kOnlineFixAppId)
-            *pAppId = real;
-        bool result = oIClientRemoteStorage_FileExists(pThis, pchFile);
-        *pAppId = saved;
-        return result;
+        if (real && appId == kOnlineFixAppId)
+            appId = real;
+
+        return oIClientRemoteStorage_FileExists(
+            pThis, appId, fileRoot, pchFile);
     }
 
     LM_HOOK(IClientRemoteStorage_Dispatch, bool, void* pThis, void* pArg)


### PR DESCRIPTION
﻿## Summary

Updates the `IClientRemoteStorage::FileExists` hook to match the current Steam client's internal method ABI.

The hook now receives and forwards:

- `void* pThis`
- `AppId_t appId`
- `uint32_t fileRoot`
- `const char* pchFile`

Instead of reading the AppID from the hard-coded `pThis + 0x38` object offset, the hook now uses the explicit AppID argument and substitutes the active-route real AppID when required.

## Current Steam validation

Steam build:

`1788400362`

`steamclient64.dll` SHA-256:

`caba4826aa3501039d095aee1843a6bfb270fb43a3ab4455b2d6733223579fee`

`SteamUI.dll` SHA-256:

`cb387adefbbac64a3c1490d4275d00daf3a1e0219b4580726ef7681db7429278`

The current `IClientRemoteStorage::FileExists` target was resolved at:

`steamclient64.dll RVA 0x74FFF0`

The current-build pattern set was verified against the installed DLLs.

Result:

`ALL RUNTIME PATTERNS VALID`

## Runtime validation

Tested with the locally built Release `LumaCore.dll` loaded into the current Steam client.

Observed:

- `LumaCore.dll` loaded successfully into `steam.exe`
- both current Steam TOMLs loaded from local cache
- `hooks_installed = 42`
- `hooks_missed = []`
- `steamui_attach_state = attached`
- startup injection completed successfully
- cloud/remote-storage path exercised successfully
- Steam remained stable through real launch and cloud-sync testing

## Build validation

A clean x64 Release build completed successfully using MSVC and:

`LumaCore/build.bat --release-only --no-pause --clean`

## Scope

This PR contains only the LumaCore hook ABI correction.

The corresponding per-build Steam pattern files are handled separately in the pattern repository consumed by SFF.
